### PR TITLE
Updating nfc-mfclassic.c

### DIFF
--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -314,6 +314,7 @@ read_card(int read_unlocked)
     //need to use the R mode. We'll trigger a warning and let them proceed.
     if (magic2) {
       printf("Note: This card does not require an unlocked write (R) \n");
+      read_unlocked = 0;
     } else {
       //If User has requested an unlocked read, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {
@@ -393,6 +394,7 @@ write_card(int write_block_zero)
     //need to use the W mode. We'll trigger a warning and let them proceed.
     if (magic2) {
       printf("Note: This card does not require an unlocked write (W) \n");
+      write_block_zero = 0
     } else {
       //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -309,7 +309,7 @@ read_card(int read_unlocked)
   bool    bFailure = false;
   uint32_t uiReadBlocks = 0;
 
-  if (read_unlocke) {
+  if (read_unlocked) {
     //If the user is attempting an unlocked read, but has a direct-write type magic card, they don't 
     //need to use the R mode. We'll trigger a warning and let them proceed.
     if (magic2) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -394,7 +394,7 @@ write_card(int write_block_zero)
     //need to use the W mode. We'll trigger a warning and let them proceed.
     if (magic2) {
       printf("Note: This card does not require an unlocked write (W) \n");
-      write_block_zero = 0
+      write_block_zero = 0;
     } else {
       //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -233,11 +233,6 @@ authenticate(uint32_t uiBlock)
 static bool
 unlock_card(void)
 {
-  if (magic2) {
-    printf("Don't use R/W with this card, this is not required!\n");
-    return false;
-  }
-
   // Configure the CRC
   if (nfc_device_set_property_bool(pnd, NP_HANDLE_CRC, false) < 0) {
     nfc_perror(pnd, "nfc_configure");
@@ -314,9 +309,17 @@ read_card(int read_unlocked)
   bool    bFailure = false;
   uint32_t uiReadBlocks = 0;
 
-  if (read_unlocked)
-    if (!unlock_card())
-      return false;
+  if (read_unlocke) {
+    //If the user is attempting an unlocked read, but has a direct-write type magic card, they don't 
+    //need to use the R mode. We'll trigger a warning and let them proceed.
+    if (magic2) {
+      printf("Note: This card does not require an unlocked write (R) \n");
+    } else {
+      //If User has requested an unlocked read, but we're unable to unlock the card, we'll error out.
+      if (!unlock_card()) {
+        return false; 
+    }
+  }
 
   printf("Reading out %d blocks |", uiBlocks + 1);
   // Read the card from end to begin
@@ -384,9 +387,17 @@ write_card(int write_block_zero)
   bool    bFailure = false;
   uint32_t uiWriteBlocks = 0;
 
-  if (write_block_zero)
-    if (!unlock_card())
-      return false;
+  if (write_block_zero) {
+    //If the user is attempting an unlocked write, but has a direct-write type magic card, they don't 
+    //need to use the W mode. We'll trigger a warning and let them proceed.
+    if (magic2) {
+      printf("Note: This card does not require an unlocked write (W) \n");
+    } else {
+      //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
+      if (!unlock_card()) {
+        return false; 
+    }
+  }
 
   printf("Writing %d blocks |", uiBlocks + 1);
   // Write the card from begin to end;

--- a/utils/nfc-mfclassic.c
+++ b/utils/nfc-mfclassic.c
@@ -318,9 +318,10 @@ read_card(int read_unlocked)
       //If User has requested an unlocked read, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {
         return false; 
+      }
     }
   }
-
+  
   printf("Reading out %d blocks |", uiBlocks + 1);
   // Read the card from end to begin
   for (iBlock = uiBlocks; iBlock >= 0; iBlock--) {
@@ -396,9 +397,10 @@ write_card(int write_block_zero)
       //If User has requested an unlocked write, but we're unable to unlock the card, we'll error out.
       if (!unlock_card()) {
         return false; 
+      }
     }
   }
-
+  
   printf("Writing %d blocks |", uiBlocks + 1);
   // Write the card from begin to end;
   for (uiBlock = 0; uiBlock <= uiBlocks; uiBlock++) {


### PR DESCRIPTION
Modifying behavior relating to magic cards.
If a user has a 'magic2' card (IE, direct-write, not a 'fully magic' card) - we'll warn them that they don't need to use the W / R modes, and then proceed with the unlock operation, instead of exiting.